### PR TITLE
Increase number of events shown and add more details to each event

### DIFF
--- a/main.py
+++ b/main.py
@@ -64,10 +64,10 @@ async def sayHello(interaction: discord.Interaction):
     await interaction.response.send_message(f'Hello!')
     
     
-@client.tree.command(name="events", description="Get the current events for the gacha game Wuthering Waves", guild=GUILD_OBJECT )
+@client.tree.command(name="events", description="Get the current events for Wuthering Waves", guild=GUILD_OBJECT)
 async def list_events(interaction: discord.Interaction):
+    
     try:
-        
         await interaction.response.defer()
         
         wiki = WikiAPI(API_URL=API_URL)
@@ -77,24 +77,35 @@ async def list_events(interaction: discord.Interaction):
             await interaction.followup.send("No ongoing events right now.")
             return
         
-        event_list = [f"- {event['title']} ({event['date_range_str']})" for event in ongoing_events]
-        formatted_list = "\n".join(event_list)
-        
+        # Create a simple embed
         embed = discord.Embed(
-            title="📅 Ongoing Wuthering Waves Events",
-            description=formatted_list,
-            color=discord.Color.green()
+            title="Current Wuthering Waves Events",
+            color=discord.Color.blue(),
         )
-        embed.set_footer(text="Data from Wuthering Waves Wiki (CC-BY-SA)")
+        
+        # Format events simply
+        event_list = []
+        for event in ongoing_events:
+            name = event['title']
+            time_left = event['time_remaining'] 
+            dates = event['date_range_str']
+            
+            event_list.append(f"**{name}**\nTime left: {time_left} | {dates}")
+        
+        # Add events to embed
+        embed.description = "\n\n".join(event_list)
+        embed.set_footer(text=f"Found {len(ongoing_events)} active events • Data from Wuthering Waves Wiki")
+        
         await interaction.followup.send(embed=embed)
         
     except Exception as e:
-        print(f"Error in listing events command: {e}")
-
+        print(f"Error in events command: {e}")
+        error_msg = f"Error fetching events: {str(e)[:100]}..."  # Show first 100 chars of error
+        
         if interaction.response.is_done():
-            await interaction.followup.send("Error fetching events. Try again later")
-        else: 
-            await interaction.response.send_message("Error fetching events. Try again")
+            await interaction.followup.send(f"Error: {error_msg}")
+        else:
+            await interaction.response.send_message(f"Error: {error_msg}")
 
 client.run(TOKEN) # type: ignore - get a warning about str but this works
 

--- a/wiki_api.py
+++ b/wiki_api.py
@@ -1,9 +1,6 @@
-# Final fixed wiki_api.py file
-
 import requests
 import re
-import html
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 from typing import List, Dict, Optional, Tuple
 
 class WikiAPI:
@@ -11,7 +8,8 @@ class WikiAPI:
     def __init__(self, API_URL: str):
         self.API_URL = API_URL
     
-    def get_category_members(self, category: str, limit: int = 50) -> List[Dict]:
+    # Note: Limit should be at 500 to get more events shown in the bot, but does take longer
+    def get_category_members(self, category: str, limit: int = 500) -> List[Dict]:
         parameters = {
             "action": "query",
             "format": "json",
@@ -31,72 +29,45 @@ class WikiAPI:
             return []
     
     def get_page_content(self, title: str) -> str:
-        methods = [
-            {
-                "action": "query",
-                "format": "json",
-                "prop": "revisions",
-                "titles": title,
-                "rvprop": "content",
-                "rvslots": "main"
-            },
-            {
-                "action": "parse",
-                "format": "json",
-                "page": title,
-                "prop": "text"
-            }
-        ]
+        parameters = {
+            "action": "query",
+            "format": "json",
+            "prop": "revisions",
+            "titles": title,
+            "rvprop": "content",
+            "rvslots": "main"
+        }
         
-        for params in methods:
-            try:
-                response = requests.get(self.API_URL, params=params)
-                response.raise_for_status()
-                data = response.json()
-                
-                content = ""
-                
-                if params["action"] == "query":
-                    pages = data.get("query", {}).get("pages", {})
-                    if pages:
-                        page_data = list(pages.values())[0]
-                        revisions = page_data.get("revisions", [])
-                        if revisions:
-                            slots = revisions[0].get("slots", {})
-                            main_slot = slots.get("main", {})
-                            content = main_slot.get("*", "")
-                
-                elif params["action"] == "parse":
-                    if "parse" in data:
-                        content = data["parse"].get("text", {}).get("*", "")
-                        content = re.sub(r'<[^>]+>', '', content)
-                        content = html.unescape(content)
-                
-                if content and len(content.strip()) > 0:
-                    return content
+        try:
+            response = requests.get(self.API_URL, params=parameters)
+            response.raise_for_status()
+            data = response.json()
+            
+            pages = data.get("query", {}).get("pages", {})
+            if pages:
+                page_data = list(pages.values())[0]
+                revisions = page_data.get("revisions", [])
+                if revisions:
+                    slots = revisions[0].get("slots", {})
+                    main_slot = slots.get("main", {})
+                    return main_slot.get("*", "")
                     
-            except requests.RequestException:
-                continue
-            except Exception:
-                continue
+        except Exception as e:
+            print(f"Error getting page content for {title}: {e}")
         
         return ""
     
     def parse_datetime_from_wiki_format(self, date_str: str) -> Optional[datetime]:
-        """Parse datetime from various wiki template formats"""
         if not date_str or date_str.strip().lower() in ['none', '', 'null', 'n/a']:
             return None
             
         date_str = date_str.strip()
         
-        # Common formats used in Wuthering Waves wiki
         formats = [
-            "%Y-%m-%d %H:%M",     # 2025-09-11 04:00
-            "%Y/%m/%d %H:%M",     # 2024/08/15 13:00
-            "%Y-%m-%d",           # 2025-09-11
-            "%Y/%m/%d",           # 2024/08/15
-            "%B %d, %Y",          # September 11, 2025
-            "%b %d, %Y",          # Sep 11, 2025
+            "%Y-%m-%d %H:%M",
+            "%Y/%m/%d %H:%M", 
+            "%Y-%m-%d",
+            "%Y/%m/%d"
         ]
         
         for fmt in formats:
@@ -107,10 +78,51 @@ class WikiAPI:
         
         return None
     
-    def parse_event_dates(self, text: str, title: str = "") -> Optional[Tuple[datetime, datetime]]:
-        """Parse event dates from wiki template format"""
+    def get_clean_event_name(self, content: str, title: str) -> str:
+        """Get a clean event name for display"""
+        # Try to get the name from the wiki template
+        name_match = re.search(r'\|\s*name\s*=\s*([^\n|]+)', content)
+        if name_match:
+            name = name_match.group(1).strip()
+            if name and name != title:
+                return name
         
-        # Extract time_start and time_end from wiki template
+        # Otherwise clean up the title
+        clean_title = re.sub(r'/\d{4}-\d{2}-\d{2}$', '', title)
+        clean_title = re.sub(r'\s*\d{4}-\d{2}-\d{2}$', '', clean_title)
+        
+        return clean_title
+    
+    def get_time_remaining(self, end_date: datetime) -> str:
+        """Calculate time remaining in a readable format"""
+        if end_date.year == 2030:  # Permanent event
+            return "Permanent"
+        
+        # Make sure both datetimes are timezone-aware for comparison
+        now = datetime.now(timezone.utc)
+        
+        # If end_date is naive (no timezone), assume it's UTC
+        if end_date.tzinfo is None:
+            end_date = end_date.replace(tzinfo=timezone.utc)
+        
+        time_diff = end_date - now
+        
+        if time_diff.total_seconds() <= 0:
+            return "Ended"
+        
+        days = time_diff.days
+        hours = time_diff.seconds // 3600
+        
+        if days > 0:
+            return f"{days}d {hours}h"
+        elif hours > 0:
+            minutes = (time_diff.seconds % 3600) // 60
+            return f"{hours}h {minutes}m"
+        else:
+            minutes = time_diff.seconds // 60
+            return f"{minutes}m"
+    
+    def parse_event_dates(self, text: str, title: str = "") -> Optional[Tuple[datetime, datetime]]:
         start_match = re.search(r'\|\s*time_start\s*=\s*([^\n|]+)', text)
         end_match = re.search(r'\|\s*time_end\s*=\s*([^\n|]+)', text)
         
@@ -125,26 +137,11 @@ class WikiAPI:
             end_str = end_match.group(1).strip()
             end_date = self.parse_datetime_from_wiki_format(end_str)
         
-        # If we have both dates, return them
         if start_date and end_date:
             return (start_date, end_date)
         
-        # If we only have start date and end is "none", check for permanent events
         if start_date and (not end_match or end_match.group(1).strip().lower() == 'none'):
-            # For permanent events or events with no end date, consider them ongoing
-            return (start_date, datetime(2030, 12, 31))  # Far future date
-        
-        # Fallback: try to extract dates from title (like "Event/2024-09-16")
-        title_date_match = re.search(r'(\d{4})-(\d{2})-(\d{2})', title)
-        if title_date_match:
-            try:
-                year, month, day = map(int, title_date_match.groups())
-                date_obj = datetime(year, month, day)
-                # For title-based dates, assume it's a week-long event
-                from datetime import timedelta
-                return (date_obj, date_obj + timedelta(days=7))
-            except ValueError:
-                pass
+            return (start_date, datetime(2030, 12, 31))
         
         return None
     
@@ -161,24 +158,40 @@ class WikiAPI:
         for event in events:
             title = event["title"]
             
-            content = self.get_page_content(title)
-            if not content:
+            try:
+                content = self.get_page_content(title)
+                if not content:
+                    continue
+                
+                date_info = self.parse_event_dates(content, title)
+                if not date_info:
+                    continue
+                
+                start_date, end_date = date_info
+                
+                # Check if event is ongoing (make sure all dates are timezone-aware for comparison)
+                today_aware = today.replace(tzinfo=timezone.utc) if today.tzinfo is None else today
+                start_aware = start_date.replace(tzinfo=timezone.utc) if start_date.tzinfo is None else start_date
+                end_aware = end_date.replace(tzinfo=timezone.utc) if end_date.tzinfo is None else end_date
+                
+                if start_aware.date() <= today_aware.date() <= end_aware.date():
+                    clean_name = self.get_clean_event_name(content, title)
+                    time_remaining = self.get_time_remaining(end_date)
+                    
+                    current_events.append({
+                        "title": clean_name,
+                        "time_remaining": time_remaining,
+                        "start_date": start_date,
+                        "end_date": end_date,
+                        "date_range_str": f"{start_date.strftime('%m/%d')} - {end_date.strftime('%m/%d') if end_date.year != 2030 else 'Permanent'}"
+                    })
+            
+            except Exception as e:
+                print(f"Error processing event {title}: {e}")
                 continue
-            
-            date_info = self.parse_event_dates(content, title)
-            if not date_info:
-                continue
-            
-            start_date, end_date = date_info
-            
-            # Check if event is ongoing
-            if start_date.date() <= today.date() <= end_date.date():
-                current_events.append({
-                    "title": title,
-                    "start_date": start_date,
-                    "end_date": end_date,
-                    "date_range_str": f"{start_date.strftime('%B %d, %Y')} → {end_date.strftime('%B %d, %Y')}"
-                })
+        
+        # Sort by end date (soonest ending first)
+        current_events.sort(key=lambda x: x['end_date'] if x['end_date'].year != 2030 else datetime.max)
         
         return current_events
 


### PR DESCRIPTION
Update the wiki limit to accommodate the maximum amount specified in the MediaWiki API, which is 500. Update the bot command logic to display the events in categories, as well as include the time left for these events